### PR TITLE
Fixes fatal error caused by not finding any subscribers

### DIFF
--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -165,6 +165,10 @@ function comment_tracker_get_subscriptions($hook, $type, $subscriptions, $params
 		'limit' => false,
 	));
 
+	if (!$users) {
+		return $subscriptions;
+	}
+
 	// Get a comma separated list of the subscribed users
 	$user_guids = array();
 	foreach ($users as $user) {


### PR DESCRIPTION
The subscriptions hook was assuming that there will always be subscribers. Now it checks whether there are any before it attempts to proceed.
